### PR TITLE
Typo in rdtrace.c?

### DIFF
--- a/src/main/rdtrace.c
+++ b/src/main/rdtrace.c
@@ -125,8 +125,7 @@ uint64_t timestamp() {
 #ifdef __MACH__
     t = clock_gettime_nsec_np(CLOCK_MONOTONIC);
 #else
-    struct timespec ts;
-    uint64_t
+    struct timespec ts;    
     clock_gettime(CLOCK_MONOTONIC, &ts);
     t = ts.tv_sec * 1e9 + ts.tv_nsec;
 #endif


### PR DESCRIPTION
Removed line. Doesn't compile otherwise. It probably won't show up always due to #ifdef.