### PR TITLE
Fix event_type for promise_expression_lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ stamp-docs
 /src/**/all.R
 .Rproj.user
 src/library/rdt/..Rcheck
+cscope.out
+cscope.files

--- a/rdt-plugins/promises/src/rdt_promises.cpp
+++ b/rdt-plugins/promises/src/rdt_promises.cpp
@@ -316,7 +316,7 @@ struct trace_promises {
         prom_info_t info = rec.promise_expression_lookup_get_info(prom, rho);
         if (info.prom_id >= 0) {
             rec.promise_expression_lookup_process(info);
-            rec.promise_lifecycle_process({info.prom_id, 1, STATE(gc_trigger_counter)});
+            rec.promise_lifecycle_process({info.prom_id, 3, STATE(gc_trigger_counter)});
         }
 
         UNPROTECT(2);


### PR DESCRIPTION
When promise expression is retrieved by substitute function, the tracer
records it with the event_type 1. This is indistinguishable from the
normal promise value lookup which is also recorded with event_type 1.
This commit changes the event_type for promise expression lookup to 3.
The analysis can now use this to distinguish between value lookup and
expression lookup.