### PR TITLE
Add support for accessing R_Newhashpjw from the dyntracer

### DIFF
--- a/src/include/Rdyntrace.h
+++ b/src/include/Rdyntrace.h
@@ -714,6 +714,7 @@ SEXP dyntracer_destroy_sexp(SEXP dyntracer_sexp,
 SEXP get_named_list_element(const SEXP list, const char *name);
 char *serialize_sexp(SEXP s);
 const char *get_string(SEXP sexp);
+int newhashpjw(const char *s);
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/dyntrace.c
+++ b/src/main/dyntrace.c
@@ -202,3 +202,7 @@ inline const char *get_string(SEXP sexp) {
 
     return CHAR(STRING_ELT(sexp, 0));
 }
+
+int newhashpjw(const char *s) {
+    return R_Newhashpjw(s);
+}


### PR DESCRIPTION
`R_Newhashpjw` is hidden and inaccessible by dyntracers which are
loaded as dlls. This commit adds a function `newhashpjw` which is
not hidden and delegates to `R_Newhashpjw`. This lets dyntracers
access `R_Newhashpjw` indirectly by calling `newhashpjw`.