### PR TITLE
Add logging functionality, change `do_dyntrace` behavior

### DIFF
--- a/src/include/Rdyntrace.h
+++ b/src/include/Rdyntrace.h
@@ -16,298 +16,299 @@ extern "C" {
 #ifdef ENABLE_DYNTRACE
 
 #define DYNTRACE_PROBE_HEADER(probe_name)                                      \
-  if (dyntrace_active_dyntracer != NULL &&                                     \
-      dyntrace_active_dyntracer->probe_name != NULL &&                         \
-      !dyntrace_is_priviliged_mode()) {                                        \
-    dyntrace_active_dyntrace_context->dyntracing_context->execution_time       \
-        .expression += dyntrace_reset_stopwatch();                             \
-    dyntrace_active_dyntrace_context->dyntracing_context->execution_count      \
-        .probe_name++;                                                         \
-    CHECK_REENTRANCY(probe_name);                                              \
-    dyntrace_active_dyntracer_probe_name = #probe_name;                        \
-    dyntrace_disable_garbage_collector();
+    if (dyntrace_active_dyntracer != NULL &&                                   \
+        dyntrace_active_dyntracer->probe_name != NULL &&                       \
+        !dyntrace_is_priviliged_mode()) {                                      \
+        dyntrace_active_dyntrace_context->dyntracing_context->execution_time   \
+            .expression += dyntrace_reset_stopwatch();                         \
+        dyntrace_active_dyntrace_context->dyntracing_context->execution_count  \
+            .probe_name++;                                                     \
+        CHECK_REENTRANCY(probe_name);                                          \
+        dyntrace_active_dyntracer_probe_name = #probe_name;                    \
+        dyntrace_disable_garbage_collector();
 
 #define DYNTRACE_PROBE_FOOTER(probe_name)                                      \
-  dyntrace_reinstate_garbage_collector();                                      \
-  dyntrace_active_dyntracer_probe_name = NULL;                                 \
-  dyntrace_active_dyntrace_context->dyntracing_context->execution_time         \
-      .probe_name += dyntrace_reset_stopwatch();                               \
-  }
+    dyntrace_reinstate_garbage_collector();                                    \
+    dyntrace_active_dyntracer_probe_name = NULL;                               \
+    dyntrace_active_dyntrace_context->dyntracing_context->execution_time       \
+        .probe_name += dyntrace_reset_stopwatch();                             \
+    }
 
 #define CHECK_REENTRANCY(probe_name)                                           \
-  if (dyntrace_check_reentrancy) {                                             \
-    if (dyntrace_active_dyntracer_probe_name != NULL) {                        \
-      Rf_error("[ERROR] - [NESTED HOOK EXECUTION] - %s triggers %s\n",         \
-               dyntrace_active_dyntracer_probe_name, #probe_name);             \
-    }                                                                          \
-  }
+    if (dyntrace_check_reentrancy) {                                           \
+        if (dyntrace_active_dyntracer_probe_name != NULL) {                    \
+            dyntrace_log_error("[NESTED HOOK EXECUTION] - %s triggers %s",     \
+                               dyntrace_active_dyntracer_probe_name,           \
+                               #probe_name);                                   \
+        }                                                                      \
+    }
 
 #define DYNTRACE_PROBE_BEGIN(prom)                                             \
-  DYNTRACE_PROBE_HEADER(probe_begin);                                          \
-  PROTECT(prom);                                                               \
-  dyntrace_active_dyntracer->probe_begin(dyntrace_active_dyntrace_context,     \
-                                         prom);                                \
-  UNPROTECT(1);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_begin);
+    DYNTRACE_PROBE_HEADER(probe_begin);                                        \
+    PROTECT(prom);                                                             \
+    dyntrace_active_dyntracer->probe_begin(dyntrace_active_dyntrace_context,   \
+                                           prom);                              \
+    UNPROTECT(1);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_begin);
 
 #define DYNTRACE_PROBE_END()                                                   \
-  DYNTRACE_PROBE_HEADER(probe_end);                                            \
-  dyntrace_active_dyntracer->probe_end(dyntrace_active_dyntrace_context);      \
-  DYNTRACE_PROBE_FOOTER(probe_end);
+    DYNTRACE_PROBE_HEADER(probe_end);                                          \
+    dyntrace_active_dyntracer->probe_end(dyntrace_active_dyntrace_context);    \
+    DYNTRACE_PROBE_FOOTER(probe_end);
 
 #define DYNTRACE_SHOULD_PROBE(probe_name)                                      \
-  (dyntrace_active_dyntracer->probe_name != NULL)
+    (dyntrace_active_dyntracer->probe_name != NULL)
 
 #define DYNTRACE_PROBE_FUNCTION_ENTRY(call, op, rho)                           \
-  DYNTRACE_PROBE_HEADER(probe_function_entry);                                 \
-  PROTECT(call);                                                               \
-  PROTECT(op);                                                                 \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_function_entry(                             \
-      dyntrace_active_dyntrace_context, call, op, rho);                        \
-  UNPROTECT(3);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_function_entry);
+    DYNTRACE_PROBE_HEADER(probe_function_entry);                               \
+    PROTECT(call);                                                             \
+    PROTECT(op);                                                               \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_function_entry(                           \
+        dyntrace_active_dyntrace_context, call, op, rho);                      \
+    UNPROTECT(3);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_function_entry);
 
 #define DYNTRACE_PROBE_FUNCTION_EXIT(call, op, rho, retval)                    \
-  DYNTRACE_PROBE_HEADER(probe_function_exit);                                  \
-  PROTECT(call);                                                               \
-  PROTECT(op);                                                                 \
-  PROTECT(rho);                                                                \
-  PROTECT(retval);                                                             \
-  dyntrace_active_dyntracer->probe_function_exit(                              \
-      dyntrace_active_dyntrace_context, call, op, rho, retval);                \
-  UNPROTECT(4);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_function_exit);
+    DYNTRACE_PROBE_HEADER(probe_function_exit);                                \
+    PROTECT(call);                                                             \
+    PROTECT(op);                                                               \
+    PROTECT(rho);                                                              \
+    PROTECT(retval);                                                           \
+    dyntrace_active_dyntracer->probe_function_exit(                            \
+        dyntrace_active_dyntrace_context, call, op, rho, retval);              \
+    UNPROTECT(4);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_function_exit);
 
 #define DYNTRACE_PROBE_BUILTIN_ENTRY(call, op, rho)                            \
-  DYNTRACE_PROBE_HEADER(probe_builtin_entry);                                  \
-  PROTECT(call);                                                               \
-  PROTECT(op);                                                                 \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_builtin_entry(                              \
-      dyntrace_active_dyntrace_context, call, op, rho);                        \
-  UNPROTECT(3);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_builtin_entry);
+    DYNTRACE_PROBE_HEADER(probe_builtin_entry);                                \
+    PROTECT(call);                                                             \
+    PROTECT(op);                                                               \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_builtin_entry(                            \
+        dyntrace_active_dyntrace_context, call, op, rho);                      \
+    UNPROTECT(3);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_builtin_entry);
 
 #define DYNTRACE_PROBE_BUILTIN_EXIT(call, op, rho, retval)                     \
-  DYNTRACE_PROBE_HEADER(probe_builtin_exit);                                   \
-  PROTECT(call);                                                               \
-  PROTECT(op);                                                                 \
-  PROTECT(rho);                                                                \
-  PROTECT(retval);                                                             \
-  dyntrace_active_dyntracer->probe_builtin_exit(                               \
-      dyntrace_active_dyntrace_context, call, op, rho, retval);                \
-  UNPROTECT(4);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_builtin_exit);
+    DYNTRACE_PROBE_HEADER(probe_builtin_exit);                                 \
+    PROTECT(call);                                                             \
+    PROTECT(op);                                                               \
+    PROTECT(rho);                                                              \
+    PROTECT(retval);                                                           \
+    dyntrace_active_dyntracer->probe_builtin_exit(                             \
+        dyntrace_active_dyntrace_context, call, op, rho, retval);              \
+    UNPROTECT(4);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_builtin_exit);
 
 #define DYNTRACE_PROBE_SPECIALSXP_ENTRY(call, op, rho)                         \
-  DYNTRACE_PROBE_HEADER(probe_specialsxp_entry);                               \
-  PROTECT(call);                                                               \
-  PROTECT(op);                                                                 \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_specialsxp_entry(                           \
-      dyntrace_active_dyntrace_context, call, op, rho);                        \
-  UNPROTECT(3);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_specialsxp_entry);
+    DYNTRACE_PROBE_HEADER(probe_specialsxp_entry);                             \
+    PROTECT(call);                                                             \
+    PROTECT(op);                                                               \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_specialsxp_entry(                         \
+        dyntrace_active_dyntrace_context, call, op, rho);                      \
+    UNPROTECT(3);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_specialsxp_entry);
 
 #define DYNTRACE_PROBE_SPECIALSXP_EXIT(call, op, rho, retval)                  \
-  DYNTRACE_PROBE_HEADER(probe_specialsxp_exit);                                \
-  PROTECT(call);                                                               \
-  PROTECT(op);                                                                 \
-  PROTECT(rho);                                                                \
-  PROTECT(retval);                                                             \
-  dyntrace_active_dyntracer->probe_specialsxp_exit(                            \
-      dyntrace_active_dyntrace_context, call, op, rho, retval);                \
-  UNPROTECT(4);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_specialsxp_exit);
+    DYNTRACE_PROBE_HEADER(probe_specialsxp_exit);                              \
+    PROTECT(call);                                                             \
+    PROTECT(op);                                                               \
+    PROTECT(rho);                                                              \
+    PROTECT(retval);                                                           \
+    dyntrace_active_dyntracer->probe_specialsxp_exit(                          \
+        dyntrace_active_dyntrace_context, call, op, rho, retval);              \
+    UNPROTECT(4);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_specialsxp_exit);
 
 #define DYNTRACE_PROBE_PROMISE_CREATED(prom, rho)                              \
-  DYNTRACE_PROBE_HEADER(probe_promise_created);                                \
-  PROTECT(prom);                                                               \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_promise_created(                            \
-      dyntrace_active_dyntrace_context, prom, rho);                            \
-  UNPROTECT(2);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_promise_created);
+    DYNTRACE_PROBE_HEADER(probe_promise_created);                              \
+    PROTECT(prom);                                                             \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_promise_created(                          \
+        dyntrace_active_dyntrace_context, prom, rho);                          \
+    UNPROTECT(2);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_promise_created);
 
 #define DYNTRACE_PROBE_PROMISE_FORCE_ENTRY(promise)                            \
-  DYNTRACE_PROBE_HEADER(probe_promise_force_entry);                            \
-  PROTECT(promise);                                                            \
-  dyntrace_active_dyntracer->probe_promise_force_entry(                        \
-      dyntrace_active_dyntrace_context, promise);                              \
-  UNPROTECT(1);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_promise_force_entry);
+    DYNTRACE_PROBE_HEADER(probe_promise_force_entry);                          \
+    PROTECT(promise);                                                          \
+    dyntrace_active_dyntracer->probe_promise_force_entry(                      \
+        dyntrace_active_dyntrace_context, promise);                            \
+    UNPROTECT(1);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_promise_force_entry);
 
 #define DYNTRACE_PROBE_PROMISE_FORCE_EXIT(promise)                             \
-  DYNTRACE_PROBE_HEADER(probe_promise_force_exit);                             \
-  PROTECT(promise);                                                            \
-  dyntrace_active_dyntracer->probe_promise_force_exit(                         \
-      dyntrace_active_dyntrace_context, promise);                              \
-  UNPROTECT(1);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_promise_force_exit);
+    DYNTRACE_PROBE_HEADER(probe_promise_force_exit);                           \
+    PROTECT(promise);                                                          \
+    dyntrace_active_dyntracer->probe_promise_force_exit(                       \
+        dyntrace_active_dyntrace_context, promise);                            \
+    UNPROTECT(1);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_promise_force_exit);
 
 #define DYNTRACE_PROBE_PROMISE_VALUE_LOOKUP(promise)                           \
-  DYNTRACE_PROBE_HEADER(probe_promise_value_lookup);                           \
-  PROTECT(promise);                                                            \
-  dyntrace_active_dyntracer->probe_promise_value_lookup(                       \
-      dyntrace_active_dyntrace_context, promise);                              \
-  UNPROTECT(1);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_promise_value_lookup);
+    DYNTRACE_PROBE_HEADER(probe_promise_value_lookup);                         \
+    PROTECT(promise);                                                          \
+    dyntrace_active_dyntracer->probe_promise_value_lookup(                     \
+        dyntrace_active_dyntrace_context, promise);                            \
+    UNPROTECT(1);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_promise_value_lookup);
 
 #define DYNTRACE_PROBE_PROMISE_EXPRESSION_LOOKUP(promise)                      \
-  DYNTRACE_PROBE_HEADER(probe_promise_expression_lookup);                      \
-  PROTECT(promise);                                                            \
-  dyntrace_active_dyntracer->probe_promise_expression_lookup(                  \
-      dyntrace_active_dyntrace_context, promise);                              \
-  UNPROTECT(1);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_promise_expression_lookup);
+    DYNTRACE_PROBE_HEADER(probe_promise_expression_lookup);                    \
+    PROTECT(promise);                                                          \
+    dyntrace_active_dyntracer->probe_promise_expression_lookup(                \
+        dyntrace_active_dyntrace_context, promise);                            \
+    UNPROTECT(1);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_promise_expression_lookup);
 
 #define DYNTRACE_PROBE_ERROR(call, message)                                    \
-  DYNTRACE_PROBE_HEADER(probe_error);                                          \
-  PROTECT(call);                                                               \
-  dyntrace_active_dyntracer->probe_error(dyntrace_active_dyntrace_context,     \
-                                         call, message);                       \
-  UNPROTECT(1);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_error);
+    DYNTRACE_PROBE_HEADER(probe_error);                                        \
+    PROTECT(call);                                                             \
+    dyntrace_active_dyntracer->probe_error(dyntrace_active_dyntrace_context,   \
+                                           call, message);                     \
+    UNPROTECT(1);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_error);
 
 #define DYNTRACE_PROBE_VECTOR_ALLOC(sexptype, length, bytes, srcref)           \
-  DYNTRACE_PROBE_HEADER(probe_vector_alloc);                                   \
-  dyntrace_active_dyntracer->probe_vector_alloc(                               \
-      dyntrace_active_dyntrace_context, sexptype, length, bytes, srcref);      \
-  DYNTRACE_PROBE_FOOTER(probe_vector_alloc);
+    DYNTRACE_PROBE_HEADER(probe_vector_alloc);                                 \
+    dyntrace_active_dyntracer->probe_vector_alloc(                             \
+        dyntrace_active_dyntrace_context, sexptype, length, bytes, srcref);    \
+    DYNTRACE_PROBE_FOOTER(probe_vector_alloc);
 
 #define DYNTRACE_PROBE_EVAL_ENTRY(e, rho)                                      \
-  DYNTRACE_PROBE_HEADER(probe_eval_entry);                                     \
-  PROTECT(e);                                                                  \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_eval_entry(                                 \
-      dyntrace_active_dyntrace_context, e, rho);                               \
-  UNPROTECT(2);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_eval_entry);
+    DYNTRACE_PROBE_HEADER(probe_eval_entry);                                   \
+    PROTECT(e);                                                                \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_eval_entry(                               \
+        dyntrace_active_dyntrace_context, e, rho);                             \
+    UNPROTECT(2);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_eval_entry);
 
 #define DYNTRACE_PROBE_EVAL_EXIT(e, rho, retval)                               \
-  DYNTRACE_PROBE_HEADER(probe_eval_exit);                                      \
-  PROTECT(e);                                                                  \
-  PROTECT(rho);                                                                \
-  PROTECT(retval);                                                             \
-  dyntrace_active_dyntracer->probe_eval_exit(dyntrace_active_dyntrace_context, \
-                                             e, rho, retval);                  \
-  UNPROTECT(3);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_eval_exit);
+    DYNTRACE_PROBE_HEADER(probe_eval_exit);                                    \
+    PROTECT(e);                                                                \
+    PROTECT(rho);                                                              \
+    PROTECT(retval);                                                           \
+    dyntrace_active_dyntracer->probe_eval_exit(                                \
+        dyntrace_active_dyntrace_context, e, rho, retval);                     \
+    UNPROTECT(3);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_eval_exit);
 
 #define DYNTRACE_PROBE_GC_ENTRY(size_needed)                                   \
-  DYNTRACE_PROBE_HEADER(probe_gc_entry);                                       \
-  dyntrace_active_dyntracer->probe_gc_entry(dyntrace_active_dyntrace_context,  \
-                                            size_needed);                      \
-  DYNTRACE_PROBE_FOOTER(probe_gc_entry);
+    DYNTRACE_PROBE_HEADER(probe_gc_entry);                                     \
+    dyntrace_active_dyntracer->probe_gc_entry(                                 \
+        dyntrace_active_dyntrace_context, size_needed);                        \
+    DYNTRACE_PROBE_FOOTER(probe_gc_entry);
 
 #define DYNTRACE_PROBE_GC_EXIT(gc_count, vcells, ncells)                       \
-  DYNTRACE_PROBE_HEADER(probe_gc_exit);                                        \
-  dyntrace_active_dyntracer->probe_gc_exit(dyntrace_active_dyntrace_context,   \
-                                           gc_count, vcells, ncells);          \
-  DYNTRACE_PROBE_FOOTER(probe_gc_exit);
+    DYNTRACE_PROBE_HEADER(probe_gc_exit);                                      \
+    dyntrace_active_dyntracer->probe_gc_exit(dyntrace_active_dyntrace_context, \
+                                             gc_count, vcells, ncells);        \
+    DYNTRACE_PROBE_FOOTER(probe_gc_exit);
 
 #define DYNTRACE_PROBE_GC_PROMISE_UNMARKED(promise)                            \
-  DYNTRACE_PROBE_HEADER(probe_gc_promise_unmarked);                            \
-  PROTECT(promise);                                                            \
-  dyntrace_active_dyntracer->probe_gc_promise_unmarked(                        \
-      dyntrace_active_dyntrace_context, promise);                              \
-  UNPROTECT(1);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_gc_promise_unmarked);
+    DYNTRACE_PROBE_HEADER(probe_gc_promise_unmarked);                          \
+    PROTECT(promise);                                                          \
+    dyntrace_active_dyntracer->probe_gc_promise_unmarked(                      \
+        dyntrace_active_dyntrace_context, promise);                            \
+    UNPROTECT(1);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_gc_promise_unmarked);
 
 #define DYNTRACE_PROBE_JUMP_CTXT(rho, val)                                     \
-  DYNTRACE_PROBE_HEADER(probe_jump_ctxt);                                      \
-  PROTECT(rho);                                                                \
-  PROTECT(val);                                                                \
-  dyntrace_active_dyntracer->probe_jump_ctxt(dyntrace_active_dyntrace_context, \
-                                             rho, val);                        \
-  UNPROTECT(2);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_jump_ctxt);
+    DYNTRACE_PROBE_HEADER(probe_jump_ctxt);                                    \
+    PROTECT(rho);                                                              \
+    PROTECT(val);                                                              \
+    dyntrace_active_dyntracer->probe_jump_ctxt(                                \
+        dyntrace_active_dyntrace_context, rho, val);                           \
+    UNPROTECT(2);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_jump_ctxt);
 
 #define DYNTRACE_PROBE_NEW_ENVIRONMENT(rho)                                    \
-  DYNTRACE_PROBE_HEADER(probe_new_environment);                                \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_new_environment(                            \
-      dyntrace_active_dyntrace_context, rho);                                  \
-  UNPROTECT(1);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_new_environment);
+    DYNTRACE_PROBE_HEADER(probe_new_environment);                              \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_new_environment(                          \
+        dyntrace_active_dyntrace_context, rho);                                \
+    UNPROTECT(1);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_new_environment);
 
 #define DYNTRACE_PROBE_S3_GENERIC_ENTRY(generic, object)                       \
-  DYNTRACE_PROBE_HEADER(probe_S3_generic_entry);                               \
-  PROTECT(object);                                                             \
-  dyntrace_active_dyntracer->probe_S3_generic_entry(                           \
-      dyntrace_active_dyntrace_context, generic, object);                      \
-  UNPROTECT(1);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_S3_generic_entry);
+    DYNTRACE_PROBE_HEADER(probe_S3_generic_entry);                             \
+    PROTECT(object);                                                           \
+    dyntrace_active_dyntracer->probe_S3_generic_entry(                         \
+        dyntrace_active_dyntrace_context, generic, object);                    \
+    UNPROTECT(1);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_S3_generic_entry);
 
 #define DYNTRACE_PROBE_S3_GENERIC_EXIT(generic, object, retval)                \
-  DYNTRACE_PROBE_HEADER(probe_S3_generic_exit);                                \
-  PROTECT(object);                                                             \
-  PROTECT(retval);                                                             \
-  dyntrace_active_dyntracer->probe_S3_generic_exit(                            \
-      dyntrace_active_dyntrace_context, generic, object, retval);              \
-  UNPROTECT(2);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_S3_generic_exit);
+    DYNTRACE_PROBE_HEADER(probe_S3_generic_exit);                              \
+    PROTECT(object);                                                           \
+    PROTECT(retval);                                                           \
+    dyntrace_active_dyntracer->probe_S3_generic_exit(                          \
+        dyntrace_active_dyntrace_context, generic, object, retval);            \
+    UNPROTECT(2);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_S3_generic_exit);
 
 #define DYNTRACE_PROBE_S3_DISPATCH_ENTRY(generic, clazz, method, object)       \
-  DYNTRACE_PROBE_HEADER(probe_S3_dispatch_entry);                              \
-  PROTECT(method);                                                             \
-  PROTECT(object);                                                             \
-  dyntrace_active_dyntracer->probe_S3_dispatch_entry(                          \
-      dyntrace_active_dyntrace_context, generic, clazz, method, object);       \
-  UNPROTECT(2);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_S3_dispatch_entry);
+    DYNTRACE_PROBE_HEADER(probe_S3_dispatch_entry);                            \
+    PROTECT(method);                                                           \
+    PROTECT(object);                                                           \
+    dyntrace_active_dyntracer->probe_S3_dispatch_entry(                        \
+        dyntrace_active_dyntrace_context, generic, clazz, method, object);     \
+    UNPROTECT(2);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_S3_dispatch_entry);
 
 #define DYNTRACE_PROBE_S3_DISPATCH_EXIT(generic, clazz, method, object,        \
                                         retval)                                \
-  DYNTRACE_PROBE_HEADER(probe_S3_dispatch_exit);                               \
-  PROTECT(method);                                                             \
-  PROTECT(object);                                                             \
-  PROTECT(retval);                                                             \
-  dyntrace_active_dyntracer->probe_S3_dispatch_exit(                           \
-      dyntrace_active_dyntrace_context, generic, clazz, method, object,        \
-      retval);                                                                 \
-  UNPROTECT(3);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_S3_dispatch_exit);
+    DYNTRACE_PROBE_HEADER(probe_S3_dispatch_exit);                             \
+    PROTECT(method);                                                           \
+    PROTECT(object);                                                           \
+    PROTECT(retval);                                                           \
+    dyntrace_active_dyntracer->probe_S3_dispatch_exit(                         \
+        dyntrace_active_dyntrace_context, generic, clazz, method, object,      \
+        retval);                                                               \
+    UNPROTECT(3);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_S3_dispatch_exit);
 
 #define DYNTRACE_PROBE_ENVIRONMENT_DEFINE_VAR(symbol, value, rho)              \
-  DYNTRACE_PROBE_HEADER(probe_environment_define_var);                         \
-  PROTECT(symbol);                                                             \
-  PROTECT(value);                                                              \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_environment_define_var(                     \
-      dyntrace_active_dyntrace_context, symbol, value, rho);                   \
-  UNPROTECT(3);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_environment_define_var);
+    DYNTRACE_PROBE_HEADER(probe_environment_define_var);                       \
+    PROTECT(symbol);                                                           \
+    PROTECT(value);                                                            \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_environment_define_var(                   \
+        dyntrace_active_dyntrace_context, symbol, value, rho);                 \
+    UNPROTECT(3);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_environment_define_var);
 
 #define DYNTRACE_PROBE_ENVIRONMENT_ASSIGN_VAR(symbol, value, rho)              \
-  DYNTRACE_PROBE_HEADER(probe_environment_assign_var);                         \
-  PROTECT(symbol);                                                             \
-  PROTECT(value);                                                              \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_environment_assign_var(                     \
-      dyntrace_active_dyntrace_context, symbol, value, rho);                   \
-  UNPROTECT(3);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_environment_assign_var);
+    DYNTRACE_PROBE_HEADER(probe_environment_assign_var);                       \
+    PROTECT(symbol);                                                           \
+    PROTECT(value);                                                            \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_environment_assign_var(                   \
+        dyntrace_active_dyntrace_context, symbol, value, rho);                 \
+    UNPROTECT(3);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_environment_assign_var);
 
 #define DYNTRACE_PROBE_ENVIRONMENT_REMOVE_VAR(symbol, rho)                     \
-  DYNTRACE_PROBE_HEADER(probe_environment_remove_var);                         \
-  PROTECT(symbol);                                                             \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_environment_remove_var(                     \
-      dyntrace_active_dyntrace_context, symbol, rho);                          \
-  UNPROTECT(2);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_environment_remove_var);
+    DYNTRACE_PROBE_HEADER(probe_environment_remove_var);                       \
+    PROTECT(symbol);                                                           \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_environment_remove_var(                   \
+        dyntrace_active_dyntrace_context, symbol, rho);                        \
+    UNPROTECT(2);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_environment_remove_var);
 
 #define DYNTRACE_PROBE_ENVIRONMENT_LOOKUP_VAR(symbol, value, rho)              \
-  DYNTRACE_PROBE_HEADER(probe_environment_lookup_var);                         \
-  PROTECT(symbol);                                                             \
-  PROTECT(value);                                                              \
-  PROTECT(rho);                                                                \
-  dyntrace_active_dyntracer->probe_environment_lookup_var(                     \
-      dyntrace_active_dyntrace_context, symbol, value, rho);                   \
-  UNPROTECT(3);                                                                \
-  DYNTRACE_PROBE_FOOTER(probe_environment_lookup_var);
+    DYNTRACE_PROBE_HEADER(probe_environment_lookup_var);                       \
+    PROTECT(symbol);                                                           \
+    PROTECT(value);                                                            \
+    PROTECT(rho);                                                              \
+    dyntrace_active_dyntracer->probe_environment_lookup_var(                   \
+        dyntrace_active_dyntrace_context, symbol, value, rho);                 \
+    UNPROTECT(3);                                                              \
+    DYNTRACE_PROBE_FOOTER(probe_environment_lookup_var);
 
 #else
 #define DYNTRACE_PROBE_BEGIN(prom)
@@ -343,334 +344,336 @@ extern "C" {
 #endif
 
 /* ----------------------------------------------------------------------------
-DYNTRACE TYPE DEFINITIONS
+   DYNTRACE TYPE DEFINITIONS
 ---------------------------------------------------------------------------- */
 
 typedef struct {
-  clock_t probe_begin;
-  clock_t probe_end;
-  clock_t probe_function_entry;
-  clock_t probe_function_exit;
-  clock_t probe_builtin_entry;
-  clock_t probe_builtin_exit;
-  clock_t probe_specialsxp_entry;
-  clock_t probe_specialsxp_exit;
-  clock_t probe_promise_created;
-  clock_t probe_promise_force_entry;
-  clock_t probe_promise_force_exit;
-  clock_t probe_promise_value_lookup;
-  clock_t probe_promise_expression_lookup;
-  clock_t probe_error;
-  clock_t probe_vector_alloc;
-  clock_t probe_eval_entry;
-  clock_t probe_eval_exit;
-  clock_t probe_gc_entry;
-  clock_t probe_gc_exit;
-  clock_t probe_gc_promise_unmarked;
-  clock_t probe_jump_ctxt;
-  clock_t probe_new_environment;
-  clock_t probe_S3_generic_entry;
-  clock_t probe_S3_generic_exit;
-  clock_t probe_S3_dispatch_entry;
-  clock_t probe_S3_dispatch_exit;
-  clock_t probe_environment_define_var;
-  clock_t probe_environment_assign_var;
-  clock_t probe_environment_remove_var;
-  clock_t probe_environment_lookup_var;
-  clock_t expression;
+    clock_t probe_begin;
+    clock_t probe_end;
+    clock_t probe_function_entry;
+    clock_t probe_function_exit;
+    clock_t probe_builtin_entry;
+    clock_t probe_builtin_exit;
+    clock_t probe_specialsxp_entry;
+    clock_t probe_specialsxp_exit;
+    clock_t probe_promise_created;
+    clock_t probe_promise_force_entry;
+    clock_t probe_promise_force_exit;
+    clock_t probe_promise_value_lookup;
+    clock_t probe_promise_expression_lookup;
+    clock_t probe_error;
+    clock_t probe_vector_alloc;
+    clock_t probe_eval_entry;
+    clock_t probe_eval_exit;
+    clock_t probe_gc_entry;
+    clock_t probe_gc_exit;
+    clock_t probe_gc_promise_unmarked;
+    clock_t probe_jump_ctxt;
+    clock_t probe_new_environment;
+    clock_t probe_S3_generic_entry;
+    clock_t probe_S3_generic_exit;
+    clock_t probe_S3_dispatch_entry;
+    clock_t probe_S3_dispatch_exit;
+    clock_t probe_environment_define_var;
+    clock_t probe_environment_assign_var;
+    clock_t probe_environment_remove_var;
+    clock_t probe_environment_lookup_var;
+    clock_t expression;
 } execution_time_t;
 
 typedef struct {
-  unsigned int probe_begin;
-  unsigned int probe_end;
-  unsigned int probe_function_entry;
-  unsigned int probe_function_exit;
-  unsigned int probe_builtin_entry;
-  unsigned int probe_builtin_exit;
-  unsigned int probe_specialsxp_entry;
-  unsigned int probe_specialsxp_exit;
-  unsigned int probe_promise_created;
-  unsigned int probe_promise_force_entry;
-  unsigned int probe_promise_force_exit;
-  unsigned int probe_promise_value_lookup;
-  unsigned int probe_promise_expression_lookup;
-  unsigned int probe_error;
-  unsigned int probe_vector_alloc;
-  unsigned int probe_eval_entry;
-  unsigned int probe_eval_exit;
-  unsigned int probe_gc_entry;
-  unsigned int probe_gc_exit;
-  unsigned int probe_gc_promise_unmarked;
-  unsigned int probe_jump_ctxt;
-  unsigned int probe_new_environment;
-  unsigned int probe_S3_generic_entry;
-  unsigned int probe_S3_generic_exit;
-  unsigned int probe_S3_dispatch_entry;
-  unsigned int probe_S3_dispatch_exit;
-  unsigned int probe_environment_define_var;
-  unsigned int probe_environment_assign_var;
-  unsigned int probe_environment_remove_var;
-  unsigned int probe_environment_lookup_var;
-  unsigned int expression;
+    unsigned int probe_begin;
+    unsigned int probe_end;
+    unsigned int probe_function_entry;
+    unsigned int probe_function_exit;
+    unsigned int probe_builtin_entry;
+    unsigned int probe_builtin_exit;
+    unsigned int probe_specialsxp_entry;
+    unsigned int probe_specialsxp_exit;
+    unsigned int probe_promise_created;
+    unsigned int probe_promise_force_entry;
+    unsigned int probe_promise_force_exit;
+    unsigned int probe_promise_value_lookup;
+    unsigned int probe_promise_expression_lookup;
+    unsigned int probe_error;
+    unsigned int probe_vector_alloc;
+    unsigned int probe_eval_entry;
+    unsigned int probe_eval_exit;
+    unsigned int probe_gc_entry;
+    unsigned int probe_gc_exit;
+    unsigned int probe_gc_promise_unmarked;
+    unsigned int probe_jump_ctxt;
+    unsigned int probe_new_environment;
+    unsigned int probe_S3_generic_entry;
+    unsigned int probe_S3_generic_exit;
+    unsigned int probe_S3_dispatch_entry;
+    unsigned int probe_S3_dispatch_exit;
+    unsigned int probe_environment_define_var;
+    unsigned int probe_environment_assign_var;
+    unsigned int probe_environment_remove_var;
+    unsigned int probe_environment_lookup_var;
+    unsigned int expression;
 } execution_count_t;
 
 typedef struct {
-  const char *r_compile_pkgs;
-  const char *r_disable_bytecode;
-  const char *r_enable_jit;
-  const char *r_keep_pkg_source;
+    const char *r_compile_pkgs;
+    const char *r_disable_bytecode;
+    const char *r_enable_jit;
+    const char *r_keep_pkg_source;
 } environment_variables_t;
 
 typedef struct {
-  execution_time_t execution_time;
-  execution_count_t execution_count;
-  environment_variables_t environment_variables;
-  const char *begin_datetime;
-  const char *end_datetime;
+    execution_time_t execution_time;
+    execution_count_t execution_count;
+    environment_variables_t environment_variables;
+    const char *begin_datetime;
+    const char *end_datetime;
 } dyntracing_context_t;
 
 typedef struct {
-  void *dyntracer_context;
-  dyntracing_context_t *dyntracing_context;
+    void *dyntracer_context;
+    dyntracing_context_t *dyntracing_context;
 } dyntrace_context_t;
 
 typedef struct {
 
-  /***************************************************************************
-  Fires when the tracer starts. Not an interpreter hook.
-  Look for DYNTRACE_PROBE_BEGIN(...) in
-  - src/main/dyntrace.c
-  ***************************************************************************/
-  void (*probe_begin)(dyntrace_context_t *dyntrace_context, const SEXP prom);
+    /***************************************************************************
+    Fires when the tracer starts. Not an interpreter hook.
+    Look for DYNTRACE_PROBE_BEGIN(...) in
+    - src/main/dyntrace.c
+    ***************************************************************************/
+    void (*probe_begin)(dyntrace_context_t *dyntrace_context, const SEXP prom);
 
-  /***************************************************************************
-  Fires when the tracer ends (after the traced call returns).
-  Not an interpreter hook.
-  Look for DYNTRACE_PROBE_END(...) in
-  - src/main/dyntrace.c
-  ***************************************************************************/
-  void (*probe_end)(dyntrace_context_t *dyntrace_context);
+    /***************************************************************************
+    Fires when the tracer ends (after the traced call returns).
+    Not an interpreter hook.
+    Look for DYNTRACE_PROBE_END(...) in
+    - src/main/dyntrace.c
+    ***************************************************************************/
+    void (*probe_end)(dyntrace_context_t *dyntrace_context);
 
-  /***************************************************************************
-  Fires on every R function call.
-  Look for DYNTRACE_PROBE_FUNCTION_ENTRY(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_function_entry)(dyntrace_context_t *dyntrace_context,
-                               const SEXP call, const SEXP op, const SEXP rho);
-
-  /***************************************************************************
-  Fires after every R function call.
-  Look for DYNTRACE_PROBE_FUNCTION_EXIT(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_function_exit)(dyntrace_context_t *dyntrace_context,
-                              const SEXP call, const SEXP op, const SEXP rho,
-                              const SEXP retval);
-
-  /***************************************************************************
-  Fires on every BUILTINSXP call.
-  Look for DYNTRACE_PROBE_BUILTIN_ENTRY(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_builtin_entry)(dyntrace_context_t *dyntrace_context,
-                              const SEXP call, const SEXP op, const SEXP rho);
-
-  /***************************************************************************
-  Fires after every BUILTINSXP call.
-  Look for DYNTRACE_PROBE_BUILTIN_EXIT(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_builtin_exit)(dyntrace_context_t *dyntrace_context,
-                             const SEXP call, const SEXP op, const SEXP rho,
-                             const SEXP retval);
-
-  /***************************************************************************
-  Fires on every SPECIALSXP call.
-  Look for DYNTRACE_PROBE_SPECIALSXP_ENTRY(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_specialsxp_entry)(dyntrace_context_t *dyntrace_context,
+    /***************************************************************************
+    Fires on every R function call.
+    Look for DYNTRACE_PROBE_FUNCTION_ENTRY(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_function_entry)(dyntrace_context_t *dyntrace_context,
                                  const SEXP call, const SEXP op,
                                  const SEXP rho);
 
-  /***************************************************************************
-  Fires after every SPECIALSXP call.
-  Look for DYNTRACE_PROBE_SPECIALSXP_EXIT(...) in
-  - in src/main/eval.c
-  ***************************************************************************/
-  void (*probe_specialsxp_exit)(dyntrace_context_t *dyntrace_context,
+    /***************************************************************************
+    Fires after every R function call.
+    Look for DYNTRACE_PROBE_FUNCTION_EXIT(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_function_exit)(dyntrace_context_t *dyntrace_context,
                                 const SEXP call, const SEXP op, const SEXP rho,
                                 const SEXP retval);
 
-  /***************************************************************************
-  Fires on promise allocation.
-  Look for DYNTRACE_PROBE_PROMISE_CREATED(...) in
-  - src/main/memory.c
-  ***************************************************************************/
-  void (*probe_promise_created)(dyntrace_context_t *dyntrace_context,
-                                const SEXP prom, const SEXP rho);
+    /***************************************************************************
+    Fires on every BUILTINSXP call.
+    Look for DYNTRACE_PROBE_BUILTIN_ENTRY(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_builtin_entry)(dyntrace_context_t *dyntrace_context,
+                                const SEXP call, const SEXP op, const SEXP rho);
 
-  /***************************************************************************
-  Fires when a promise is forced (accessed for the first time).
-  Look for DYNTRACE_PROBE_PROMISE_FORCE_ENTRY(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_promise_force_entry)(dyntrace_context_t *dyntrace_context,
-                                    const SEXP promise);
+    /***************************************************************************
+    Fires after every BUILTINSXP call.
+    Look for DYNTRACE_PROBE_BUILTIN_EXIT(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_builtin_exit)(dyntrace_context_t *dyntrace_context,
+                               const SEXP call, const SEXP op, const SEXP rho,
+                               const SEXP retval);
 
-  /***************************************************************************
-  Fires right after a promise is forced.
-  Look for DYNTRACE_PROBE_PROMISE_FORCE_EXIT(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_promise_force_exit)(dyntrace_context_t *dyntrace_context,
-                                   const SEXP promise);
+    /***************************************************************************
+    Fires on every SPECIALSXP call.
+    Look for DYNTRACE_PROBE_SPECIALSXP_ENTRY(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_specialsxp_entry)(dyntrace_context_t *dyntrace_context,
+                                   const SEXP call, const SEXP op,
+                                   const SEXP rho);
 
-  /***************************************************************************
-  Fires when a promise is accessed but already forced.
-  Look for DYNTRACE_PROBE_PROMISE_VALUE_LOOKUP(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_promise_value_lookup)(dyntrace_context_t *dyntrace_context,
+    /***************************************************************************
+    Fires after every SPECIALSXP call.
+    Look for DYNTRACE_PROBE_SPECIALSXP_EXIT(...) in
+    - in src/main/eval.c
+    ***************************************************************************/
+    void (*probe_specialsxp_exit)(dyntrace_context_t *dyntrace_context,
+                                  const SEXP call, const SEXP op,
+                                  const SEXP rho, const SEXP retval);
+
+    /***************************************************************************
+    Fires on promise allocation.
+    Look for DYNTRACE_PROBE_PROMISE_CREATED(...) in
+    - src/main/memory.c
+    ***************************************************************************/
+    void (*probe_promise_created)(dyntrace_context_t *dyntrace_context,
+                                  const SEXP prom, const SEXP rho);
+
+    /***************************************************************************
+    Fires when a promise is forced (accessed for the first time).
+    Look for DYNTRACE_PROBE_PROMISE_FORCE_ENTRY(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_promise_force_entry)(dyntrace_context_t *dyntrace_context,
+                                      const SEXP promise);
+
+    /***************************************************************************
+    Fires right after a promise is forced.
+    Look for DYNTRACE_PROBE_PROMISE_FORCE_EXIT(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_promise_force_exit)(dyntrace_context_t *dyntrace_context,
                                      const SEXP promise);
 
-  /***************************************************************************
-  Fires when the expression inside a promise is accessed.
-  Look for DYNTRACE_PROBE_PROMISE_EXPRESSION_LOOKUP(...) in
-  - src/main/coerce.c
-  ***************************************************************************/
-  void (*probe_promise_expression_lookup)(dyntrace_context_t *dyntrace_context,
-                                          const SEXP promise);
+    /***************************************************************************
+    Fires when a promise is accessed but already forced.
+    Look for DYNTRACE_PROBE_PROMISE_VALUE_LOOKUP(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_promise_value_lookup)(dyntrace_context_t *dyntrace_context,
+                                       const SEXP promise);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_ERROR(...) in
-  - src/main/errors.c
-  ***************************************************************************/
-  void (*probe_error)(dyntrace_context_t *dyntrace_context, const SEXP call,
-                      const char *message);
+    /***************************************************************************
+    Fires when the expression inside a promise is accessed.
+    Look for DYNTRACE_PROBE_PROMISE_EXPRESSION_LOOKUP(...) in
+    - src/main/coerce.c
+    ***************************************************************************/
+    void (*probe_promise_expression_lookup)(
+        dyntrace_context_t *dyntrace_context, const SEXP promise);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_VECTOR_ALLOC(...) in
-  - src/main/memory.c
-  ***************************************************************************/
-  void (*probe_vector_alloc)(dyntrace_context_t *dyntrace_context, int sexptype,
-                             long length, long bytes, const char *srcref);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_ERROR(...) in
+    - src/main/errors.c
+    ***************************************************************************/
+    void (*probe_error)(dyntrace_context_t *dyntrace_context, const SEXP call,
+                        const char *message);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_EVAL_ENTRY(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_eval_entry)(dyntrace_context_t *dyntrace_context, SEXP e,
-                           SEXP rho);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_VECTOR_ALLOC(...) in
+    - src/main/memory.c
+    ***************************************************************************/
+    void (*probe_vector_alloc)(dyntrace_context_t *dyntrace_context,
+                               int sexptype, long length, long bytes,
+                               const char *srcref);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_EVAL_EXIT(...) in
-  - src/main/eval.c
-  ***************************************************************************/
-  void (*probe_eval_exit)(dyntrace_context_t *dyntrace_context, SEXP e,
-                          SEXP rho, SEXP retval);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_EVAL_ENTRY(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_eval_entry)(dyntrace_context_t *dyntrace_context, SEXP e,
+                             SEXP rho);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_GC_ENTRY(...) in
-  - src/main/memory.c
-  ***************************************************************************/
-  void (*probe_gc_entry)(dyntrace_context_t *dyntrace_context,
-                         R_size_t size_needed);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_EVAL_EXIT(...) in
+    - src/main/eval.c
+    ***************************************************************************/
+    void (*probe_eval_exit)(dyntrace_context_t *dyntrace_context, SEXP e,
+                            SEXP rho, SEXP retval);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_GC_EXIT(...) in
-  - src/main/memory.c
-  ***************************************************************************/
-  void (*probe_gc_exit)(dyntrace_context_t *dyntrace_context, int gc_count,
-                        double vcells, double ncells);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_GC_ENTRY(...) in
+    - src/main/memory.c
+    ***************************************************************************/
+    void (*probe_gc_entry)(dyntrace_context_t *dyntrace_context,
+                           R_size_t size_needed);
 
-  /***************************************************************************
-  Fires when a promise gets garbage collected
-  Look for DYNTRACE_PROBE_GC_PROMISE_UNMARKED(...) in
-  - src/main/memory.c
-  ***************************************************************************/
-  void (*probe_gc_promise_unmarked)(dyntrace_context_t *dyntrace_context,
-                                    const SEXP promise);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_GC_EXIT(...) in
+    - src/main/memory.c
+    ***************************************************************************/
+    void (*probe_gc_exit)(dyntrace_context_t *dyntrace_context, int gc_count,
+                          double vcells, double ncells);
 
-  /***************************************************************************
-  Fires when the interpreter is about to longjump into a different context.
-  Parameter rho is the target environment.
-  Look for DYNTRACE_PROBE_JUMP_CTXT(...) in
-  - src/main/context.c
-  ***************************************************************************/
-  void (*probe_jump_ctxt)(dyntrace_context_t *dyntrace_context, const SEXP rho,
-                          const SEXP val);
+    /***************************************************************************
+    Fires when a promise gets garbage collected
+    Look for DYNTRACE_PROBE_GC_PROMISE_UNMARKED(...) in
+    - src/main/memory.c
+    ***************************************************************************/
+    void (*probe_gc_promise_unmarked)(dyntrace_context_t *dyntrace_context,
+                                      const SEXP promise);
 
-  /***************************************************************************
-  Fires when the interpreter creates a new environment.
-  Parameter rho is the newly created environment.
-  Look for DYNTRACE_PROBE_NEW_ENVIRONMENT(..) in
-  - src/main/memory.c
-  ***************************************************************************/
-  void (*probe_new_environment)(dyntrace_context_t *dyntrace_context,
-                                const SEXP rho);
+    /***************************************************************************
+    Fires when the interpreter is about to longjump into a different context.
+    Parameter rho is the target environment.
+    Look for DYNTRACE_PROBE_JUMP_CTXT(...) in
+    - src/main/context.c
+    ***************************************************************************/
+    void (*probe_jump_ctxt)(dyntrace_context_t *dyntrace_context,
+                            const SEXP rho, const SEXP val);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_S3_GENERIC_ENTRY(...) in
-  - src/main/objects.c
-  ***************************************************************************/
-  void (*probe_S3_generic_entry)(dyntrace_context_t *dyntrace_context,
-                                 const char *generic, const SEXP object);
+    /***************************************************************************
+    Fires when the interpreter creates a new environment.
+    Parameter rho is the newly created environment.
+    Look for DYNTRACE_PROBE_NEW_ENVIRONMENT(..) in
+    - src/main/memory.c
+    ***************************************************************************/
+    void (*probe_new_environment)(dyntrace_context_t *dyntrace_context,
+                                  const SEXP rho);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_S3_GENERIC_EXIT(...) in
-  - src/main/objects.c
-  ***************************************************************************/
-  void (*probe_S3_generic_exit)(dyntrace_context_t *dyntrace_context,
-                                const char *generic, const SEXP object,
-                                const SEXP retval);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_S3_GENERIC_ENTRY(...) in
+    - src/main/objects.c
+    ***************************************************************************/
+    void (*probe_S3_generic_entry)(dyntrace_context_t *dyntrace_context,
+                                   const char *generic, const SEXP object);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_S3_DISPATCH_ENTRY(...) in
-  - src/main/objects.c
-  ***************************************************************************/
-  void (*probe_S3_dispatch_entry)(dyntrace_context_t *dyntrace_context,
-                                  const char *generic, const char *clazz,
-                                  const SEXP method, const SEXP object);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_S3_GENERIC_EXIT(...) in
+    - src/main/objects.c
+    ***************************************************************************/
+    void (*probe_S3_generic_exit)(dyntrace_context_t *dyntrace_context,
+                                  const char *generic, const SEXP object,
+                                  const SEXP retval);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_S3_DISPATCH_EXIT(...) in
-  - src/main/objects.c
-  ***************************************************************************/
-  void (*probe_S3_dispatch_exit)(dyntrace_context_t *dyntrace_context,
-                                 const char *generic, const char *clazz,
-                                 const SEXP method, const SEXP object,
-                                 const SEXP retval);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_S3_DISPATCH_ENTRY(...) in
+    - src/main/objects.c
+    ***************************************************************************/
+    void (*probe_S3_dispatch_entry)(dyntrace_context_t *dyntrace_context,
+                                    const char *generic, const char *clazz,
+                                    const SEXP method, const SEXP object);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_ENVIRONMENT_DEFINE_VAR(...) in
-  - src/main/envir.c
-  ***************************************************************************/
-  void (*probe_environment_define_var)(dyntrace_context_t *dyntrace_context,
-                                       SEXP symbol, SEXP value, SEXP rho);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_S3_DISPATCH_EXIT(...) in
+    - src/main/objects.c
+    ***************************************************************************/
+    void (*probe_S3_dispatch_exit)(dyntrace_context_t *dyntrace_context,
+                                   const char *generic, const char *clazz,
+                                   const SEXP method, const SEXP object,
+                                   const SEXP retval);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_ENVIRONMENT_ASSIGN_VAR(...) in
-  - src/main/envir.c
-  ***************************************************************************/
-  void (*probe_environment_assign_var)(dyntrace_context_t *dyntrace_context,
-                                       SEXP symbol, SEXP value, SEXP rho);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_ENVIRONMENT_DEFINE_VAR(...) in
+    - src/main/envir.c
+    ***************************************************************************/
+    void (*probe_environment_define_var)(dyntrace_context_t *dyntrace_context,
+                                         SEXP symbol, SEXP value, SEXP rho);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_ENVIRONMENT_REMOVE_VAR(...) in
-  - src/main/envir.c
-  ***************************************************************************/
-  void (*probe_environment_remove_var)(dyntrace_context_t *dyntrace_context,
-                                       SEXP symbol, SEXP rho);
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_ENVIRONMENT_ASSIGN_VAR(...) in
+    - src/main/envir.c
+    ***************************************************************************/
+    void (*probe_environment_assign_var)(dyntrace_context_t *dyntrace_context,
+                                         SEXP symbol, SEXP value, SEXP rho);
 
-  /***************************************************************************
-  Look for DYNTRACE_PROBE_ENVIRONMENT_LOOKUP_VAR(...) in
-  - src/main/envir.c
-  ***************************************************************************/
-  void (*probe_environment_lookup_var)(dyntrace_context_t *dyntrace_context,
-                                       SEXP symbol, SEXP value, SEXP rho);
-  void *context;
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_ENVIRONMENT_REMOVE_VAR(...) in
+    - src/main/envir.c
+    ***************************************************************************/
+    void (*probe_environment_remove_var)(dyntrace_context_t *dyntrace_context,
+                                         SEXP symbol, SEXP rho);
+
+    /***************************************************************************
+    Look for DYNTRACE_PROBE_ENVIRONMENT_LOOKUP_VAR(...) in
+    - src/main/envir.c
+    ***************************************************************************/
+    void (*probe_environment_lookup_var)(dyntrace_context_t *dyntrace_context,
+                                         SEXP symbol, SEXP value, SEXP rho);
+    void *context;
 } dyntracer_t;
 
 // ----------------------------------------------------------------------------
@@ -679,7 +682,7 @@ typedef struct {
 
 // the current dyntracer
 extern dyntracer_t *dyntrace_active_dyntracer;
- // flag to disable reentrancy check
+// flag to disable reentrancy check
 extern int dyntrace_check_reentrancy;
 // name of currently executing probe
 extern const char *dyntrace_active_dyntracer_probe_name;
@@ -719,6 +722,20 @@ SEXP get_named_list_element(const SEXP list, const char *name);
 char *serialize_sexp(SEXP s);
 const char *get_string(SEXP sexp);
 int newhashpjw(const char *s);
+void NORET jump_to_top_ex(Rboolean, Rboolean, Rboolean, Rboolean, Rboolean);
+
+#define dyntrace_log_error(error, ...)                                         \
+    do { Rprintf("DYNTRACE LOG - ERROR - %s · %s(...) · %d - " error "\n", __FILE__, __func__, __LINE__, ##__VA_ARGS__); \
+        dyntrace_active_dyntracer_probe_name = NULL;                           \
+        jump_to_top_ex(TRUE, TRUE, TRUE, TRUE, FALSE);                         \
+    } while (0);
+
+#define dyntrace_log_warning(warning, ...)                                     \
+    Rprintf("DYNTRACE LOG - WARNING - %s · %s(...) · %d - " warning "\n", __FILE__, __func__, __LINE__, ##__VA_ARGS__);
+
+#define dyntrace_log_info(info, ...)                                           \
+    Rprintf("DYNTRACE LOG - INFO - %s · %s(...) · %d - " info "\n", __FILE__, __func__, __LINE__, ##__VA_ARGS__);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/dyntrace.c
+++ b/src/main/dyntrace.c
@@ -1,18 +1,18 @@
 #include <Rdyntrace.h>
 #include <Rinternals.h>
+#include <deparse.h>
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <deparse.h>
 
 #if !defined(HAVE_CLOCK_GETTIME) && defined(__MACH__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
 
-dyntrace_context_t * dyntrace_active_dyntrace_context = NULL;
+dyntrace_context_t *dyntrace_active_dyntrace_context = NULL;
 dyntracer_t *dyntrace_active_dyntracer = NULL;
 int dyntrace_check_reentrancy = 1;
 const char *dyntrace_active_dyntracer_probe_name = NULL;
@@ -20,16 +20,14 @@ int dyntrace_garbage_collector_state = 0;
 clock_t dyntrace_stopwatch;
 int dyntrace_privileged_mode_flag = 0;
 
-dyntracer_t * dyntracer_from_sexp(SEXP dyntracer_sexp) {
+dyntracer_t *dyntracer_from_sexp(SEXP dyntracer_sexp) {
     return (dyntracer_t *)R_ExternalPtrAddr(dyntracer_sexp);
 }
 
-SEXP dyntracer_to_sexp(dyntracer_t *dyntracer,
-                       const char *classname) {
+SEXP dyntracer_to_sexp(dyntracer_t *dyntracer, const char *classname) {
     SEXP dyntracer_sexp;
-    PROTECT(dyntracer_sexp = R_MakeExternalPtr(dyntracer,
-                                               install(classname),
-                                               R_NilValue));
+    PROTECT(dyntracer_sexp =
+                R_MakeExternalPtr(dyntracer, install(classname), R_NilValue));
     SEXP dyntracer_class = PROTECT(allocVector(STRSXP, 1));
     SET_STRING_ELT(dyntracer_class, 0, mkChar(classname));
     classgets(dyntracer_sexp, dyntracer_class);
@@ -37,102 +35,103 @@ SEXP dyntracer_to_sexp(dyntracer_t *dyntracer,
     return dyntracer_sexp;
 }
 
-dyntracer_t * dyntracer_replace_sexp(SEXP dyntracer_sexp,
-                                     dyntracer_t * new_dyntracer) {
-    dyntracer_t * old_dyntracer = R_ExternalPtrAddr(dyntracer_sexp);
+dyntracer_t *dyntracer_replace_sexp(SEXP dyntracer_sexp,
+                                    dyntracer_t *new_dyntracer) {
+    dyntracer_t *old_dyntracer = R_ExternalPtrAddr(dyntracer_sexp);
     R_SetExternalPtrAddr(dyntracer_sexp, new_dyntracer);
     return old_dyntracer;
 }
 
 SEXP dyntracer_destroy_sexp(SEXP dyntracer_sexp,
-                            void (*destroy_dyntracer)(dyntracer_t * dyntracer)) {
-    dyntracer_t * dyntracer = dyntracer_replace_sexp(dyntracer_sexp, NULL);
+                            void (*destroy_dyntracer)(dyntracer_t *dyntracer)) {
+    dyntracer_t *dyntracer = dyntracer_replace_sexp(dyntracer_sexp, NULL);
     /* free dyntracer iff it has not already been freed.
        this check ensures that multiple calls to destroy_dyntracer on the same
        object do not crash the process. */
-    if(dyntracer != NULL)
-      destroy_dyntracer(dyntracer);
+    if (dyntracer != NULL)
+        destroy_dyntracer(dyntracer);
     return R_NilValue;
 }
 
-void dyntrace_enable_privileged_mode() {
-    dyntrace_privileged_mode_flag = 1;
-}
+void dyntrace_enable_privileged_mode() { dyntrace_privileged_mode_flag = 1; }
 
-void dyntrace_disable_privileged_mode() {
-    dyntrace_privileged_mode_flag = 0;
-}
+void dyntrace_disable_privileged_mode() { dyntrace_privileged_mode_flag = 0; }
 
-int dyntrace_is_priviliged_mode() {
-    return dyntrace_privileged_mode_flag;  
-}
+int dyntrace_is_priviliged_mode() { return dyntrace_privileged_mode_flag; }
 
-static const char * get_current_datetime() {
+static const char *get_current_datetime() {
     time_t current_time = time(NULL);
-    char * time_string = ctime(&current_time);
+    char *time_string = ctime(&current_time);
     return strtok(time_string, "\n"); // remove new-lines
 }
 
-static void assign_environment_variables(environment_variables_t * environment_variables) {
-    environment_variables -> r_compile_pkgs = getenv("R_COMPILE_PKGS");
-    environment_variables -> r_disable_bytecode = getenv("R_DISABLE_BYTECODE");
-    environment_variables -> r_enable_jit = getenv("R_ENABLE_JIT");
-    environment_variables -> r_keep_pkg_source = getenv("R_KEEP_PKG_SOURCE");
+static void
+assign_environment_variables(environment_variables_t *environment_variables) {
+    environment_variables->r_compile_pkgs = getenv("R_COMPILE_PKGS");
+    environment_variables->r_disable_bytecode = getenv("R_DISABLE_BYTECODE");
+    environment_variables->r_enable_jit = getenv("R_ENABLE_JIT");
+    environment_variables->r_keep_pkg_source = getenv("R_KEEP_PKG_SOURCE");
 }
 
-static dyntracing_context_t * create_dyntracing_context() {
+static dyntracing_context_t *create_dyntracing_context() {
     // calloc ensures that execution times are all set to 0. If we malloc
     // instead, we have to explicitly set all execution times to 0;
-    dyntracing_context_t * dyntracing_context = calloc(1, sizeof(dyntracing_context_t));
-    assign_environment_variables(&(dyntracing_context -> environment_variables));
+    dyntracing_context_t *dyntracing_context =
+        calloc(1, sizeof(dyntracing_context_t));
+    assign_environment_variables(&(dyntracing_context->environment_variables));
     return dyntracing_context;
 }
 
-static dyntrace_context_t * create_dyntrace_context(dyntracer_t * dyntracer) {
-    dyntrace_context_t * dyntrace_context = calloc(1, sizeof(dyntrace_context_t));
-    dyntrace_context -> dyntracer_context = dyntracer -> context;
-    dyntrace_context -> dyntracing_context = create_dyntracing_context();
+static dyntrace_context_t *create_dyntrace_context(dyntracer_t *dyntracer) {
+    dyntrace_context_t *dyntrace_context =
+        calloc(1, sizeof(dyntrace_context_t));
+    dyntrace_context->dyntracer_context = dyntracer->context;
+    dyntrace_context->dyntracing_context = create_dyntracing_context();
     return dyntrace_context;
 }
 
-static void destroy_dyntrace_context(dyntrace_context_t * dyntrace_context) {
-    free(dyntrace_context -> dyntracing_context);
+static void destroy_dyntrace_context(dyntrace_context_t *dyntrace_context) {
+    free(dyntrace_context->dyntracing_context);
     free(dyntrace_context);
 }
 
 SEXP do_dyntrace(SEXP call, SEXP op, SEXP args, SEXP rho) {
     int eval_error = FALSE;
     SEXP expression, environment, result;
-    dyntracer_t * dyntracer = NULL;
-    dyntracer_t * dyntrace_previous_dyntracer = dyntrace_active_dyntracer;
+    dyntracer_t *dyntracer = NULL;
+    dyntracer_t *dyntrace_previous_dyntracer = dyntrace_active_dyntracer;
 
     /* extract objects from argument list */
     dyntracer = dyntracer_from_sexp(eval(CAR(args), rho));
     PROTECT(expression = findVar(CADR(args), rho));
     PROTECT(environment = eval(CADDR(args), rho));
 
-    if(dyntracer == NULL)
-      error("dyntracer is NULL");
+    if (dyntracer == NULL)
+        error("dyntracer is NULL");
     /* create dyntrace context */
-    dyntrace_active_dyntrace_context = create_dyntrace_context(dyntracer);    
+    dyntrace_active_dyntrace_context = create_dyntrace_context(dyntracer);
 
     /* begin dyntracing */
     dyntrace_active_dyntracer = dyntracer;
     dyntrace_stopwatch = clock();
-    dyntrace_active_dyntrace_context -> dyntracing_context -> begin_datetime = get_current_datetime();
+    dyntrace_active_dyntrace_context->dyntracing_context->begin_datetime =
+        get_current_datetime();
 
     DYNTRACE_PROBE_BEGIN(expression);
 
     /* continue dyntracing */
     PROTECT(result = R_tryEval(expression, environment, &eval_error));
-    if(eval_error) {
-        REprintf("error while dyntracing code block\n");
+    if (eval_error) {
+        /* we want to return a sensible result for
+           evaluation of the expression */
         result = R_NilValue;
+    } else {
+      /* end dyntracing */
+      dyntrace_active_dyntrace_context->dyntracing_context->end_datetime =
+        get_current_datetime();
+      DYNTRACE_PROBE_END();
     }
 
-    /* end dyntracing */
-    dyntrace_active_dyntrace_context -> dyntracing_context -> end_datetime = get_current_datetime();
-    DYNTRACE_PROBE_END();
     dyntrace_active_dyntracer = dyntrace_previous_dyntracer;
 
     /* destroy dyntrace context */
@@ -176,21 +175,34 @@ SEXP get_named_list_element(const SEXP list, const char *name) {
     SEXP names = getAttrib(list, R_NamesSymbol);
 
     for (int i = 0; i < length(list); i++) {
-        if (strcmp(CHAR(STRING_ELT(names, i)), name) == 0) { 
-            e = VECTOR_ELT(list, i); 
-            break; 
+        if (strcmp(CHAR(STRING_ELT(names, i)), name) == 0) {
+            e = VECTOR_ELT(list, i);
+            break;
         }
     }
 
     return e;
 }
 
-char* serialize_sexp(SEXP s) {
+char *serialize_sexp(SEXP s) {
 
-    LocalParseData parse_data = {0, 0, 0, 0, /*startline = */TRUE, 0,
-                                 NULL, /*DeparseBuffer=*/{NULL, 0, BUFSIZE},
-                                 INT_MAX, FALSE, 0, TRUE, FALSE,
-                                 INT_MAX, TRUE, 0, FALSE};
+    LocalParseData parse_data = {0,
+                                 0,
+                                 0,
+                                 0,
+                                 /*startline = */ TRUE,
+                                 0,
+                                 NULL,
+                                 /*DeparseBuffer=*/{NULL, 0, BUFSIZE},
+                                 INT_MAX,
+                                 FALSE,
+                                 0,
+                                 TRUE,
+                                 FALSE,
+                                 INT_MAX,
+                                 TRUE,
+                                 0,
+                                 FALSE};
     parse_data.linenumber = 0;
     parse_data.indent = 0;
     deparse2buff(s, &parse_data);
@@ -205,6 +217,4 @@ inline const char *get_string(SEXP sexp) {
     return CHAR(STRING_ELT(sexp, 0));
 }
 
-int newhashpjw(const char *s) {
-    return R_Newhashpjw(s);
-}
+int newhashpjw(const char *s) { return R_Newhashpjw(s); }

--- a/src/main/errors.c
+++ b/src/main/errors.c
@@ -55,7 +55,7 @@ static int noBreakWarning = 0;
 
 static void try_jump_to_restart(void);
 // The next is crucial to the use of NORET attributes.
-static void NORET
+void NORET
 jump_to_top_ex(Rboolean, Rboolean, Rboolean, Rboolean, Rboolean);
 static void signalInterrupt(void);
 static char * R_ConciseTraceback(SEXP call, int skip);
@@ -869,7 +869,7 @@ static void try_jump_to_restart(void)
 /* calling the code installed by on.exit along the way */
 /* and finally longjmping to the innermost TOPLEVEL context */
 
-static void jump_to_top_ex(Rboolean traceback,
+void jump_to_top_ex(Rboolean traceback,
 			   Rboolean tryUserHandler,
 			   Rboolean processWarnings,
 			   Rboolean resetConsole,


### PR DESCRIPTION
This commit adds functionality to log errors, warnings and traces.
These are implemented as macros which print useful information such
as file name, function name and line number from where they are
called.
`dyntrace_log_error` jumps to top level after printing the error.
This lets the users jump out of tracing when an error is encountered
but keeps them in the existing R session for more interactions.

The behavior of `do_dyntrace` function has been modified.
`DYNTRACE_PROBE_END` is no longer called when the dyntracing
encounters errors, either because of R code or because of
the tracer.

The code has been reformatted using `clang-format` to ensure uniform
indentation and style.

Resolves #160