### PR TITLE
Fix expression serialization

### DIFF
--- a/src/main/deparse.c
+++ b/src/main/deparse.c
@@ -501,11 +501,6 @@ SEXP attribute_hidden do_dump(SEXP call, SEXP op, SEXP args, SEXP rho)
 
 static void linebreak(Rboolean *lbreak, LocalParseData *d)
 {
-#ifdef ENABLE_DYNTRACE
-    if(dyntrace_is_active()) {
-        return;
-    }
-#endif
     if (d->len > d->cutoff) {
 	if (!*lbreak) {
 	    *lbreak = TRUE;
@@ -1287,7 +1282,11 @@ static void writeline(LocalParseData *d)
 {
 #ifdef ENABLE_DYNTRACE
     if(dyntrace_is_active()) {
-        return;
+      print2buff("\n", d);
+      d->linenumber++;
+      /* reset */
+      d->startline = TRUE;
+      return;
     }
 #endif
     if (d->strvec != R_NilValue && d->linenumber < d->maxlines)

--- a/src/main/dyntrace.c
+++ b/src/main/dyntrace.c
@@ -193,7 +193,7 @@ char *serialize_sexp(SEXP s) {
                                  /*startline = */ TRUE,
                                  0,
                                  NULL,
-                                 /*DeparseBuffer=*/{NULL, 0, BUFSIZE},
+                                 /*DeparseBuffer=*/{NULL, 0, 1024 * 1024},
                                  INT_MAX,
                                  FALSE,
                                  0,


### PR DESCRIPTION
This commit fixes the serialization of R expressions.
Earlier, newline and indentation were being ignored
while serializing leading to unreadable serialized
expressions. This commit ensures proper serialization
of R objects, just like they are printed in R console.
The default size of `parse_data` buffer in `serialize_sexp`
function has been updated to 1 MB. This reduces the
possibility of multiple reallocations while serializing
expressions.