### PR TITLE
Fix serialization of very large vectors

### DIFF
--- a/src/main/deparse.c
+++ b/src/main/deparse.c
@@ -1353,6 +1353,20 @@ static void vector2buff(SEXP vector, LocalParseData *d)
 	quote = '"';
     else
 	quote = 0;
+
+#ifdef ENABLE_DYNTRACE
+    if(dyntrace_is_active() && tlen > 5) {
+      char vector_size[20];
+      sprintf(vector_size, "%d", tlen);
+      print2buff("<vector(", d);
+      print2buff(sexptype2char(TYPEOF(vector)), d);
+      print2buff(")[", d);
+      print2buff(vector_size, d);
+      print2buff("]>", d);
+      return;
+    }
+#endif
+
     if (tlen == 0) {
 	switch(TYPEOF(vector)) {
 	case LGLSXP: print2buff("logical(0)", d); break;

--- a/src/main/dyntrace.c
+++ b/src/main/dyntrace.c
@@ -205,6 +205,7 @@ char *serialize_sexp(SEXP s) {
                                  FALSE};
     parse_data.linenumber = 0;
     parse_data.indent = 0;
+    parse_data.opts = 32;
     deparse2buff(s, &parse_data);
     return parse_data.buffer.data;
 }


### PR DESCRIPTION
This commit fixes the serialization of very large vectors.
Vectors of size greater than 5 are serialized as
`vector(type)[size]`. This is helpful as we are serializing
call expressions and promise expressions and they can
sometimes contain very big vectors.